### PR TITLE
Add missing as_slice method to BufSplit

### DIFF
--- a/blog/2020-02-01/Implementing-A-Copyless-Redis-Protocol-in-Rust-With-Parsing-Combinators.org
+++ b/blog/2020-02-01/Implementing-A-Copyless-Redis-Protocol-in-Rust-With-Parsing-Combinators.org
@@ -506,6 +506,14 @@ The conversion function is actually pretty mechanical:
 #+begin_src rust
   // First, we need a convenient way to convert our index pairs into byte slices.
   impl BufSplit {
+      /// Get a lifetime appropriate slice of the underlying buffer.
+      ///
+      /// Constant time.
+      #[inline]
+      fn as_slice<'a>(&self, buf: &'a BytesMut) -> &'a [u8] {
+          &buf[self.0..self.1]
+      }
+
       /// Get a Bytes object representing the appropriate slice
       /// of bytes.
       ///


### PR DESCRIPTION
The code sample at section about Parsing ints
[Parsing Ints](https://dpbriggs.ca/blog/Implementing-A-Copyless-Redis-Protocol-in-Rust-With-Parsing-Combinators#org5c8973b) uses the `as_slice` method which is missing at [Putting it all together](https://dpbriggs.ca/blog/Implementing-A-Copyless-Redis-Protocol-in-Rust-With-Parsing-Combinators#orge30edaf)

So copied this change from the [red-oxide repo](https://github.com/dpbriggs/redis-oxide/blob/546b1490683976a60aca83774603c33a42a47164/src/asyncresp.rs#L63-L69).

Thanks for doing the write up!